### PR TITLE
fix: authenticate GitHub CLI using GH_PAT to resolve 401 error

### DIFF
--- a/.github/workflows/label-inheritance.yaml
+++ b/.github/workflows/label-inheritance.yaml
@@ -14,6 +14,11 @@ jobs:
       - name: Install jq
         run: sudo apt-get install -y jq
 
+      - name: Authenticate GitHub CLI
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: echo "${GH_TOKEN}" | gh auth login --with-token
+
       - name: Set up environment
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
Previously, the GitHub CLI failed with a "Bad credentials (HTTP 401)" error when attempting GraphQL API calls. This was due to missing explicit authentication.

This commit adds a step to authenticate `gh` using the provided GH_PAT via `gh auth login --with-token`. This ensures all subsequent `gh api` commands are authorized correctly during workflow execution.