### PR TITLE
Regenerate GH_PAT and update workflow to debug 401 error

### DIFF
--- a/.github/workflows/label-inheritance.yaml
+++ b/.github/workflows/label-inheritance.yaml
@@ -6,14 +6,22 @@ on:
 
 permissions:
   contents: read
-  issues: write  # 🔧 Added to allow label modification
+  issues: write
 
 jobs:
   inherit-labels:
     runs-on: ubuntu-latest
     steps:
-      - name: Install jq
-        run: sudo apt-get install -y jq
+      - name: Debug GH_TOKEN
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "❌ GH_TOKEN is not set"
+            exit 1
+          fi
+          echo "✅ GH_TOKEN is set (length: ${#GH_TOKEN})"
+          gh auth status || { echo "❌ GH_TOKEN authentication failed"; exit 1; }
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
 
       - name: Get parent issue and inherit labels
         env:
@@ -48,7 +56,7 @@ jobs:
 
           echo "🔍 Issue node ID: $ISSUE_ID"
 
-          echo "Querying for parent issue using GraphQL preview headers..."
+          echo "Querying for parent issue using GraphQL..."
           PARENT_JSON=$(gh api graphql \
             -H "GraphQL-Features: sub_issues,issue_types" \
             -f issueId="$ISSUE_ID" \
@@ -58,7 +66,7 @@ jobs:
                   ... on Issue {
                     parent {
                       number
-                      labels(first: 20) {
+                      labels(first: 100) {
                         nodes {
                           name
                         }
@@ -88,17 +96,20 @@ jobs:
             exit 0
           fi
 
-          echo "✅ Inheriting labels from parent issue #$PARENT_NUMBER: $LABELS"
+          echo "✅ Inheriting labels from parent issue #$PARENT_NUMBER: $(echo "$LABELS" | jq -r '.[]')"
+
+          echo "Fetching current labels..."
+          CURRENT_LABELS=$(gh api -H "Accept: application/vnd.github+json" \
+            /repos/${REPO_OWNER}/${REPO_NAME}/issues/${ISSUE_NUMBER} \
+            --jq '.labels[].name' | jq -R . | jq -s .)
+          MERGED_LABELS=$(echo "$CURRENT_LABELS $LABELS" | jq -s 'flatten | unique')
 
           echo "Applying labels via REST API..."
-          HTTP_CODE=$(curl -s -o response.json -w "%{http_code}" -X POST \
-            -H "Authorization: token $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/issues/${ISSUE_NUMBER}/labels \
-            -d "{\"labels\": $LABELS}")
-
-          if [ "$HTTP_CODE" -ne 200 ]; then
-            echo "❌ Failed to apply labels. HTTP $HTTP_CODE"
+          gh api -X POST -H "Accept: application/vnd.github+json" \
+            /repos/${REPO_OWNER}/${REPO_NAME}/issues/${ISSUE_NUMBER}/labels \
+            -f "labels=$MERGED_LABELS" > response.json
+          if [ $? -ne 0 ]; then
+            echo "❌ Failed to apply labels"
             cat response.json
             exit 1
           fi


### PR DESCRIPTION
- Regenerated GH_PAT with `repo` scope to fix `Bad credentials (HTTP 401)` error
- Updated label-inheritance.yaml:
  - Added `Debug GH_TOKEN` step to verify token presence and authentication
  - Removed unnecessary `jq` installation (pre-installed on ubuntu-latest)
  - Added label merging to preserve existing issue labels
  - Switched REST API call from `curl` to `gh api` for security
  - Increased GraphQL label limit to `first: 100`
- Tested token locally and updated repository secret